### PR TITLE
Fixed so ports other than 80 works

### DIFF
--- a/conf/LocalSettings.php
+++ b/conf/LocalSettings.php
@@ -320,3 +320,6 @@ $wgUploadWizardConfig = [
     };
 // 10kx10k
 $wgMaxImageArea = 10e7;
+
+# Hopefully this shouldn't affect production in any bad way
+$wgCanonicalServer = 'http://localhost:80';

--- a/conf/LocalSettings.php
+++ b/conf/LocalSettings.php
@@ -197,8 +197,15 @@ $wgDiscordWebhookURL = [ getenv('DISCORD_WEBHOOK') ];
 $wgSharedTables[] = 'global_user_groups';
 
 ## VisualEditor
-$wgVirtualRestConfig['modules']['parsoid'] = array(
-);
+if (getenv('WIKI_ENV') === 'Dev') {
+    // Fixes issues related to the visual editor not working on anything but port 80
+    $wgVirtualRestConfig['modules']['parsoid'] = array(
+        'url' => 'http://localhost/rest.php'
+    );
+} else {
+    $wgVirtualRestConfig['modules']['parsoid'] = array(
+    );
+}
 
 ## Semantic Mediawki
 $smwgConfigFileDir = $IP . "/semantics_config";
@@ -320,6 +327,3 @@ $wgUploadWizardConfig = [
     };
 // 10kx10k
 $wgMaxImageArea = 10e7;
-
-# Hopefully this shouldn't affect production in any bad way
-$wgCanonicalServer = 'http://localhost:80';

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -26,7 +26,7 @@ server {
     
     # Rewrite / to point to /w/
     location / {
-        return 301 ./w/;
+        rewrite ^/$ ./w/ permanent;
     }
 
     # Fix rest.php

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -26,7 +26,7 @@ server {
     
     # Rewrite / to point to /w/
     location / {
-        rewrite ^/$ /w/ permanent;
+        return 301 ./w/;
     }
 
     # Fix rest.php


### PR DESCRIPTION
Fixed issue #10.
Fixed so `localhost:X/` redirects to `localhost:X/w/`.
Fixed so the visual editor works regardless of the port.